### PR TITLE
Update chrony.conf file check for Centos7 standard location.

### DIFF
--- a/controls/2_2_special_purpose_services.rb
+++ b/controls/2_2_special_purpose_services.rb
@@ -95,8 +95,12 @@ control 'cis-dil-benchmark-2.2.1.3' do
     package('chrony').installed? || command('chronyd').exist?
   end
 
-  describe file('/etc/chrony/chrony.conf') do
-    its(:content) { should match(/^server\s+\S+/) }
+  describe.one do
+    #w(/etc/chrony/chrony.conf /etc/chrony.conf).each do |f|
+      describe file(f) do
+        its(:content) { should match(/^server\s+\S+/) }
+      end
+    end
   end
 
   describe processes('chronyd') do


### PR DESCRIPTION
Adding an additional option to check for existence of -u ntp:ntp, which is where it shows up on the latest Amazon Linux.